### PR TITLE
Update the collection mapping in the Classificationstore

### DIFF
--- a/models/DataObject/Classificationstore.php
+++ b/models/DataObject/Classificationstore.php
@@ -453,7 +453,7 @@ class Classificationstore extends Model\AbstractModel implements DirtyIndicatorI
      */
     public function setGroupCollectionMapping($groupId = null, $collectionId = null)
     {
-        if (!is_array($this->groupCollectionMapping) && $groupId) {
+        if (is_array($this->groupCollectionMapping) && $groupId) {
             $this->groupCollectionMapping[$groupId] = $collectionId;
         }
     }


### PR DESCRIPTION
The !Isarray check prevent all updates of the collection map.


<!--
## Please make sure your PR complies with all of the following points: 
- [x] Read and accept our [contributing guidelines](/CONTRIBUTING.md) before you submit a PR.
- [x] Features need to be proper documented in `doc/`
- [x] Bugfixes need a short guide how to reproduce them. 
- [x] We're not accepting any feature PR's only for **version 5** anymore, you have to provide a feature PR for both versions. 
- [x] Submit bugfixes for version 5 to the target branch `5.8`, version 6 is `master` branch.
- [x] Please try to meet all level 2 requirements according to [PHPStan tests](/doc/Development_Documentation/19_Development_Tools_and_Details/29_Testing/02_Core_Tests.md)

**Don't submit a PR if it doesn't comply, it'll be closed without a comment!**
-->  
  

## Changes in this pull request  
Resolves #
The Classificationstore methos setGroupCollectionMapping($groupId = null, $collectionId = null)  cannot update the mapping array 

## Additional info  

